### PR TITLE
ci: add typecheck and build CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# 読み取り専用: install/typecheck/build のみでリポジトリへ書き込まないため
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run build


### PR DESCRIPTION
## Summary

This repo had no CI — `.github/` contained only `mcp-config.json`. This PR adds a GitHub Actions workflow so every push to `main` and every pull request is type-checked and built.

## Problem fixed

- **No CI existed** → type errors and build breakage could land on `main` unnoticed.
  - `.github/workflows/ci.yml` (new)

## What the workflow does

Runs the existing `package.json` scripts (verified present):

- `npm ci` — install against the committed `package-lock.json`
- `npm run typecheck` — `react-router typegen && tsc`
- `npm run build` — `react-router build`

There is **no `test` script** in `package.json`, so no test step was added (per spec: skip test unless a real script exists).

## Fleet-wide hardening applied

- `permissions: { contents: read }` — every job only checks out, installs, type-checks and builds; nothing writes to the repo.
- `concurrency` with `cancel-in-progress: true` — supersede stale runs on the same ref.
- `timeout-minutes: 15` — guard the build job.

## Checklist

- [x] Workflow triggers on `push` (main) + `pull_request`
- [x] `actions/setup-node@v4` with `cache: npm`, Node 22 (matches `@types/node ^22`)
- [x] Runs existing `typecheck` + `build` scripts
- [x] `test` skipped (no test script present)
- [x] Read-only `permissions`, `concurrency`, `timeout-minutes` set
- [x] YAML validated
- [x] No husky/hooks added (spec preferred CI-only)


---
_Generated by [Claude Code](https://claude.ai/code/session_011FLbbgmTJkjve2bRRCBGeF)_